### PR TITLE
use fs.writeFileSync() to avoid fs.writeFile() callback function undefined error

### DIFF
--- a/test.js
+++ b/test.js
@@ -8,5 +8,7 @@ var json = JSON.parse(fs.readFileSync(process.argv[3]));
 console.log("start transform");
 var result = script.transform(json)
 console.log("finish transform");
-fs.writeFile("output.json", JSON.stringify(result));
+fs.writeFile("output.json", JSON.stringify(result), (err) => {
+  if (err) throw err;
+});
 console.log("finish write result to output.json");

--- a/test.js
+++ b/test.js
@@ -8,7 +8,5 @@ var json = JSON.parse(fs.readFileSync(process.argv[3]));
 console.log("start transform");
 var result = script.transform(json)
 console.log("finish transform");
-fs.writeFile("output.json", JSON.stringify(result), (err) => {
-  if (err) throw err;
-});
+fs.writeFileSync("output.json", JSON.stringify(result));
 console.log("finish write result to output.json");


### PR DESCRIPTION
In latest node, fs.writeFile() needs define callback function:
   <code>function writeFile(path: PathLike | number, data: any, callback: NoParamCallback): void;</code>
Otherwise it will throw error:
![image](https://user-images.githubusercontent.com/25164547/79192887-202afa80-7e5c-11ea-9e38-2bdd46410191.png)